### PR TITLE
Suggestions for examples of acronyms used in scientific writing

### DIFF
--- a/tests/50-markdown-math-longname/expected.md
+++ b/tests/50-markdown-math-longname/expected.md
@@ -1,10 +1,13 @@
 # List Of Acronyms {#acronyms_HEADER_LOA .loa}
 
+[CV]{#acronyms_CV}
+:   $\frac{\sigma}{\mu}$
+
 [$E$]{#acronyms_energy}
 :   $E = mc^2$
 
 # Introduction {#intro}
 
-First mention: [$E$ ($E = mc^2$)](#acronyms_energy).
+First mention: [$E$ ($E = mc^2$)](#acronyms_energy) and [CV ($\frac{\sigma}{\mu}$)](#acronyms_CV).
 
-Second mention: [$E$](#acronyms_energy).
+Second mention: [$E$](#acronyms_energy) and [CV](#acronyms_CV).

--- a/tests/50-markdown-math-longname/input.qmd
+++ b/tests/50-markdown-math-longname/input.qmd
@@ -5,10 +5,14 @@ acronyms:
     - key: energy
       shortname: "$E$"
       longname: "$E = mc^2$"
+    - key: CV
+      shortname: "CV"
+      longname: "$\\frac{\\sigma}{\\mu}$"
 ---
 
 # Introduction {#intro}
 
-First mention: \acr{energy}.
+First mention: \acr{energy} and {{< acr CV >}}.
 
-Second mention: \acr{energy}.
+Second mention: \acr{energy} and {{< acr CV >}}.
+

--- a/tests/51-markdown-math-shortname/expected.md
+++ b/tests/51-markdown-math-shortname/expected.md
@@ -1,10 +1,13 @@
 # List Of Acronyms {#acronyms_HEADER_LOA .loa}
 
+[$P_\text{L}$]{#acronyms_PL}
+:   transpulmonary pressure
+
 [$e^{x}$]{#acronyms_eq}
 :   Exponential function
 
 # Introduction {#intro}
 
-First mention: [$e^{x}$ (Exponential function)](#acronyms_eq).
+First mention: [$e^{x}$ (Exponential function)](#acronyms_eq) and [$P_\text{L}$ (transpulmonary pressure)](#acronyms_PL).
 
-Second mention: [$e^{x}$](#acronyms_eq).
+Second mention: [$e^{x}$](#acronyms_eq) and [$P_\text{L}$](#acronyms_PL).

--- a/tests/51-markdown-math-shortname/input.qmd
+++ b/tests/51-markdown-math-shortname/input.qmd
@@ -5,10 +5,13 @@ acronyms:
     - key: eq
       shortname: $e^{x}$
       longname: Exponential function
+    - key: PL
+      shortname: "$P_\\text{L}$"
+      longname: "transpulmonary pressure"
 ---
 
 # Introduction {#intro}
 
-First mention: \acr{eq}.
+First mention: \acr{eq} and {{< acr PL >}}.
 
-Second mention: \acr{eq}.
+Second mention: \acr{eq} and {{< acr PL >}}.


### PR DESCRIPTION
In this PR I provide two examples from my own work that serve as examples how math can be used in short and long versions of acronyms.

There are some things to note:

- When using tex commands inside math (e.g., `\sin`, `\frac`, etc), they should have a double `\\` in the acronym definition. Otherwise, it could be interpreted as e.g., `\t`, which translates to a tab. 
- When rendering math-only long or short version to docx, the equations are rendered as standalone equations in the list of acronyms. This results in them being centered and treated as a separate 'paragraph'. I don't know what the origin of this issue is (e.g., whether it's in quarto, Pandoc or in Word itself). This issue does not exist when converting to PDF via typst. 
- Equations can take up more vertical space than normal text, resulting in surrounding parentheses that look too small (see example about the fraction in the long form of CV). Inside equations, this can be solved by using `\left(` and `\right)` instead of normal parentheses. In this package, the parentheses are put in as text, not as part of the equation, so that is not an option.

I don't think the issues mentioned above should be 'fixed'. It would be nice to have them work more intuitively, but I think this is acceptable, if the caveats are mentioned somewhere.